### PR TITLE
Fix custom uri signing, verification and re-signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@nanopub/sign": "^0.1.10",
     "@rdfjs/data-model": "^2.1.1",
     "n3": "^1.26.0",
     "rdf-canonize": "^5.0.0",

--- a/src/sign/sign-rs.ts
+++ b/src/sign/sign-rs.ts
@@ -1,0 +1,17 @@
+export async function sign(
+  rdf: string,
+  privateKey: string,
+  orcid: string,
+  name: string
+): Promise<{ signedRdf: string; sourceUri: string; signature: string }> {
+  const { Nanopub, NpProfile } = (await import("@nanopub/sign/bundler.js"));
+
+  const wasmNp = new Nanopub(rdf);
+  const signed = wasmNp.sign(new NpProfile(privateKey, orcid, name));
+
+  return {
+    signedRdf: signed.rdf(),
+    sourceUri: signed.info().uri,
+    signature: signed.info().signature,
+  };
+}

--- a/src/sign/sign-rs.ts
+++ b/src/sign/sign-rs.ts
@@ -2,9 +2,9 @@ export async function sign(
   rdf: string,
   privateKey: string,
   orcid: string,
-  name: string
+  name: string,
 ): Promise<{ signedRdf: string; sourceUri: string; signature: string }> {
-  const { Nanopub, NpProfile } = (await import("@nanopub/sign/bundler.js"));
+  const { Nanopub, NpProfile } = await import('@nanopub/sign/bundler.js');
 
   const wasmNp = new Nanopub(rdf);
   const signed = wasmNp.sign(new NpProfile(privateKey, orcid, name));

--- a/src/sign/sign.ts
+++ b/src/sign/sign.ts
@@ -9,12 +9,17 @@ import { makeTrusty } from './trusty';
 
 const { namedNode, literal, quad } = DataFactory;
 
-function detectNanopubBaseUri(dataset: Store): string {
+export function detectNanopubBaseUri(dataset: Store): {baseUri: string, trustyUri?: string} {
   const typeQuads = dataset.getQuads(null, RDF('type'), NP('Nanopublication'), null);
   if (typeQuads.length > 0) {
-    return typeQuads[0].subject.value;
+    const uri = typeQuads[0].subject.value;
+    // Detect whether it is a trusty URI, if so return the prefix, otherwise the placeholder
+    const match = uri.match(/\/(RA|RB|FA)([A-Za-z0-9_-]{43})(?=[/#]|$)/);
+    let baseUri = match ? uri.substring(0, match.index! + 1) : uri;
+    baseUri = baseUri.endsWith('/') ? baseUri : `${baseUri}/`;
+    return { baseUri, trustyUri: match ? uri : undefined };
   }
-  return DEFAULT_NANOPUB_URI;
+  return { baseUri: DEFAULT_NANOPUB_URI, trustyUri: undefined };
 }
 
 function replaceNanopubUri(dataset: Store, oldBase: string, newBase: string): Store {
@@ -56,20 +61,31 @@ export async function sign(
   privateKeyBase64: string,
   orcid?: string,
 ): Promise<{ signedRdf: string; sourceUri: string; signature: string }> {
+  // We need to handle 3 major cases of signing a nanopub:
+  //  A. Nanopub with the normal DEFAULT_NANOPUB_URI placeholder prefix -> resulting in output with TRUSTY_BASE prefix
+  //  B. Nanopub with a custom placeholder prefix -> resulting in output with that placeholder prefix
+  //  C. Nanopub which is being re-signed (already has an existingTrustyUri) -> replace the existingTrustyUri with the detected prefix, use the same prefix in the output
 
   const adapter = await getCryptoAdapter();
   const publicKeyBase64 = await adapter.extractPublicKey(privateKeyBase64);
 
   const quads = parse(trig, 'trig');
   let dataset: Store = new Store(quads);
-  const placeholder = detectNanopubBaseUri(dataset);
+  // detectNanopubBaseUri() ensures the baseUri always ends in slash
+  const { baseUri: placeholder, trustyUri: existingTrustyUri } = detectNanopubBaseUri(dataset);
   const placeholderNoSlash = placeholder.replace(/\/$/, '');
+
+  if (existingTrustyUri) {
+    // For case C. replace the existing trustyUri with the same detected placeholder prefix
+    trig = trig.replace(new RegExp(existingTrustyUri, 'g'), placeholderNoSlash)
+    const quads = parse(trig, 'trig');
+    dataset = new Store(quads);
+  }
 
   dataset = replaceBnodes(dataset, placeholder);
 
-  const subUri = placeholder.endsWith('/') ? placeholder : `${placeholder}/`;
-  const pubinfoGraph = namedNode(`${subUri}pubinfo`);
-  const sigNode = namedNode(`${subUri}sig`);
+  const pubinfoGraph = namedNode(`${placeholder}pubinfo`);
+  const sigNode = namedNode(`${placeholder}sig`);
 
   // Strip any existing signature quads so that re-signing a loaded nanopub
   // does not leave duplicate hasPublicKey / hasSignature triples.
@@ -87,33 +103,23 @@ export async function sign(
     dataset.addQuad(quad(sigNode, NPX('signedBy'), namedNode(orcid), pubinfoGraph));
   }
 
+  // For case A. we use TRUSTY_BASE, and for case B. and C. we use the same placeholder
+  const trustyBase = (placeholder === DEFAULT_NANOPUB_URI ? TRUSTY_BASE : placeholder)
+
   // Step 1: normalize without signature (using placeholder URIs)
-  const normalizedForSignature = normalizeDataset(dataset, placeholder, TRUSTY_BASE, '/');
+  const normalizedForSignature = normalizeDataset(dataset, placeholder, trustyBase, '/');
   const signature = await adapter.sign(normalizedForSignature, privateKeyBase64);
 
   // Step 2: add hasSignature (still with placeholder URIs)
   dataset.addQuad(quad(sigNode, NPX('hasSignature'), literal(signature), pubinfoGraph));
 
   // Step 3: normalize WITH signature > compute trusty hash
-  const normalizedForTrusty = normalizeDataset(dataset, placeholder, TRUSTY_BASE, '/');
+  const normalizedForTrusty = normalizeDataset(dataset, placeholder, trustyBase, '/');
   const artifactCode = await makeTrusty(normalizedForTrusty);
-  // Use the input's own base for the trusty URI. Remap to TRUSTY_BASE when:
-  // - input is the default temp placeholder, or
-  // - input is already a trusty URI (starts with TRUSTY_BASE) to avoid double-nesting.
+
   // Step 4: replace placeholder URIs with trusty URI
-  const defaultNoSlash = DEFAULT_NANOPUB_URI.replace(/\/$/, '');
-  const trustyNoSlash = TRUSTY_BASE.replace(/\/$/, '');
-
-  const trustyBase =
-    placeholderNoSlash === defaultNoSlash
-      ? TRUSTY_BASE
-      : placeholderNoSlash.startsWith(trustyNoSlash)
-        ? TRUSTY_BASE
-        : placeholderNoSlash;
-
   const trustyBaseNoSlash = trustyBase.replace(/\/$/, '');
   const trustyUri = `${trustyBaseNoSlash}/${artifactCode}`;
-
   dataset = replaceNanopubUri(dataset, placeholder, trustyUri);
 
   const trustyPubinfoGraph = namedNode(`${trustyUri}/pubinfo`);

--- a/src/sign/verify.ts
+++ b/src/sign/verify.ts
@@ -3,8 +3,8 @@ import { parse } from '../serialize';
 import { Store } from 'n3';
 import { normalizeDataset } from './utils';
 import { makeTrusty } from './trusty';
-import { TRUSTY_BASE } from '../constants';
 import { NPX } from '../vocab';
+import { detectNanopubBaseUri } from './sign';
 
 export type VerificationResult =
   | { valid: true }
@@ -28,8 +28,10 @@ export async function verifySignature(trig: string): Promise<VerificationResult>
   if (!targetQuad) throw new Error('No signature target found');
   const nanopubUri = targetQuad.object.value;
 
+  const { baseUri } = detectNanopubBaseUri(dataset);
+
   // Check 1: trusty hash
-  const normalizedForHash = normalizeDataset(dataset, nanopubUri, TRUSTY_BASE, '/');
+  const normalizedForHash = normalizeDataset(dataset, nanopubUri, baseUri, '/');
   const computedHash = await makeTrusty(normalizedForHash);
   if (!nanopubUri.endsWith(computedHash)) {
     return { valid: false, reason: 'hash_mismatch' };
@@ -37,7 +39,7 @@ export async function verifySignature(trig: string): Promise<VerificationResult>
 
   // Check 2: cryptographic signature
   dataset.removeQuad(sigQuad);
-  const normalized = normalizeDataset(dataset, nanopubUri, TRUSTY_BASE, '/');
+  const normalized = normalizeDataset(dataset, nanopubUri, baseUri, '/');
   const adapter = await getCryptoAdapter();
   const sigValid = await adapter.verify(normalized, signature, publicKeyBase64);
   if (!sigValid) {

--- a/tests/sign/sign-custom-uri.test.ts
+++ b/tests/sign/sign-custom-uri.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { generateKeyPairSync } from 'crypto';
+import { describe, it, expect } from 'vitest';
 import { sign } from '../../src/sign/sign';
 import { sign as sign_rs } from '../../src/sign/sign-rs';
 

--- a/tests/sign/sign-custom-uri.test.ts
+++ b/tests/sign/sign-custom-uri.test.ts
@@ -1,14 +1,43 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { generateKeyPairSync } from 'crypto';
 import { sign } from '../../src/sign/sign';
- import { sign as sign_rs } from '../../src/sign/sign-rs';
+import { sign as sign_rs } from '../../src/sign/sign-rs';
 
-const ORCID = 'https://orcid.org/0000-0000-0000-0000';
+const ORCID = 'https://orcid.org/0000-9999-1234-9999';
+const NAME = 'Test User1';
 
 const EXAMPLE_privateKey =
-  "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNQEcoXXchdpTm71Tidhyr1BMJp8jYeVg7/oLbmE5WOJ0hilSH/bmivywB+HoTOr6/3tpinw0Bws2M2m/7LLnDaaeYB5RC2DoD2BKBa499yOHa3rGMGOh/viyCGOJbjFPINlMhsIzsr+wvktHw0JclfW508lHmudjzR1/6B3OPdbj6Xw292VHIRt2WdyCmPEc8/3zvzuycQ3xsURnMxRoAdFqIf5iP30pn9uqP+Ex1rUaZ4lbrU8AuNPys3fiIPDVTYgsh4alY/IcYvd5OCvn2uw4LoXd/JZb9EJuS1KYK9v/DRirCdlvSNh4hy5UE7/nNgmXDt3xYjDfzOYN/8N9hAgMBAAECggEANbec5/OOOjPOxKHelWZUGqRmVyCScBVSAmGZ3d7+oZIvjZemh/DfpLhjzCA70syNH6ozfZwiy1MweKyyogoSlBISyrcxFk2A4YCrVzPPWhw5AA9IaGIcd1JOU74vf8Y6JywQlcCfIVLpfYnvaBcvd6BcSD8jMD9ziDgl5koM9H5iVDAr/J7XTm7iRxT3keCmfwBSs1rI0HB156e/QvG8eX/XX4hqrTJsRzC9S6wwkD/KSxan+ZHqN5d5eRI/3g9AYXNRqj0Nq2GOR2m4yC4UbL3ua7gEGxueErbKIm6uzWnCZSSV5fWXAALCmgILHeMpMMTej9+nd9ha2D3gJAoAAQKBgQDPV2sXW97OaL7jnTKd6tFbPgjrZ4YdkP917XTpOkhldJmiwhCDWo5BUSeo0aihB0rYwDNpGNgyBA9BNM5lBSCWrpAT3FMWrsUX6Y5Lg9UBaY5eXATmqf29YZPrWHG5b0vuU4MB59GzMPzAnzlysxLarzPbQBvXSeCNwLXtTKukcQKBgQD9a0Yb7FMNNHQlG8lOkftGRRIBejt+KPpg4cLF57nZJ5xgYaky+aiJLzZaof2Tmo7tsB3tlHv59opA9BCjB6iJ23OXTuO1Z5nqwH/PLe3m9QUd3syRgJ9a04is/GdxcUWUFG8shIBn1Gv0AYvZPwYXLduvdU5mnfTwKJfClvCh8QKBgQCfG3Mniq1QcZrCadf0zMP5I4KOunN1btZKNXz4mGwDxtU6y3cGhVASmWc4qiKf50utRthsts74mprmK9KSPLwERVJ0myb7igPe1LAIDNNA8TJ6AF0WcK4xTJbJC6bBaMG40kb/CFioDFh4q/bWqMo4HChMAEcdDykNPiudPK+eUQKBgQCWKuIxm7mfIo0MjEme0Gx4uGcyDu+AE+JCVKVpRqZfYtSMXHK57S0Mlbh8vm8X70dw26LwbMOGXKySTs4o/VnGzw7RA4N1tH2FmSpjZ5EJAfpVN/g65GAJnz3nW+4kT/3uAKncVGwOmtaZke0AABOo2pjKgRXDQyiowzUirvTK0QKBgQDOKqcTGGphC1pIpF/SUtdya0YXNoNoPtFBG5YmWjW0X7MonCisR0ffMsbqJWD00q2rzNG9kTU6u/3lKHrFFVktFQRYj4DJcLBxowt2j/WNiUOekFFw/xFbTCq7Sb2IoYUnQQPETKkrSq1WaAJ30rQRjhbXlpTPBOXj+tUrZ/BS+w==";
+  'MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNQEcoXXchdpTm71Tidhyr1BMJp8jYeVg7/oLbmE5WOJ0hilSH/bmivywB+HoTOr6/3tpinw0Bws2M2m/7LLnDaaeYB5RC2DoD2BKBa499yOHa3rGMGOh/viyCGOJbjFPINlMhsIzsr+wvktHw0JclfW508lHmudjzR1/6B3OPdbj6Xw292VHIRt2WdyCmPEc8/3zvzuycQ3xsURnMxRoAdFqIf5iP30pn9uqP+Ex1rUaZ4lbrU8AuNPys3fiIPDVTYgsh4alY/IcYvd5OCvn2uw4LoXd/JZb9EJuS1KYK9v/DRirCdlvSNh4hy5UE7/nNgmXDt3xYjDfzOYN/8N9hAgMBAAECggEANbec5/OOOjPOxKHelWZUGqRmVyCScBVSAmGZ3d7+oZIvjZemh/DfpLhjzCA70syNH6ozfZwiy1MweKyyogoSlBISyrcxFk2A4YCrVzPPWhw5AA9IaGIcd1JOU74vf8Y6JywQlcCfIVLpfYnvaBcvd6BcSD8jMD9ziDgl5koM9H5iVDAr/J7XTm7iRxT3keCmfwBSs1rI0HB156e/QvG8eX/XX4hqrTJsRzC9S6wwkD/KSxan+ZHqN5d5eRI/3g9AYXNRqj0Nq2GOR2m4yC4UbL3ua7gEGxueErbKIm6uzWnCZSSV5fWXAALCmgILHeMpMMTej9+nd9ha2D3gJAoAAQKBgQDPV2sXW97OaL7jnTKd6tFbPgjrZ4YdkP917XTpOkhldJmiwhCDWo5BUSeo0aihB0rYwDNpGNgyBA9BNM5lBSCWrpAT3FMWrsUX6Y5Lg9UBaY5eXATmqf29YZPrWHG5b0vuU4MB59GzMPzAnzlysxLarzPbQBvXSeCNwLXtTKukcQKBgQD9a0Yb7FMNNHQlG8lOkftGRRIBejt+KPpg4cLF57nZJ5xgYaky+aiJLzZaof2Tmo7tsB3tlHv59opA9BCjB6iJ23OXTuO1Z5nqwH/PLe3m9QUd3syRgJ9a04is/GdxcUWUFG8shIBn1Gv0AYvZPwYXLduvdU5mnfTwKJfClvCh8QKBgQCfG3Mniq1QcZrCadf0zMP5I4KOunN1btZKNXz4mGwDxtU6y3cGhVASmWc4qiKf50utRthsts74mprmK9KSPLwERVJ0myb7igPe1LAIDNNA8TJ6AF0WcK4xTJbJC6bBaMG40kb/CFioDFh4q/bWqMo4HChMAEcdDykNPiudPK+eUQKBgQCWKuIxm7mfIo0MjEme0Gx4uGcyDu+AE+JCVKVpRqZfYtSMXHK57S0Mlbh8vm8X70dw26LwbMOGXKySTs4o/VnGzw7RA4N1tH2FmSpjZ5EJAfpVN/g65GAJnz3nW+4kT/3uAKncVGwOmtaZke0AABOo2pjKgRXDQyiowzUirvTK0QKBgQDOKqcTGGphC1pIpF/SUtdya0YXNoNoPtFBG5YmWjW0X7MonCisR0ffMsbqJWD00q2rzNG9kTU6u/3lKHrFFVktFQRYj4DJcLBxowt2j/WNiUOekFFw/xFbTCq7Sb2IoYUnQQPETKkrSq1WaAJ30rQRjhbXlpTPBOXj+tUrZ/BS+w==';
 
-const inputTrig = `<https://w3id.org/sciencelive/np/Head> {
+// An input to be signed, containing the normal placeholder URI
+const inputTrigStandard = `<http://purl.org/nanopub/temp/np/Head> {
+<http://purl.org/nanopub/temp/np/> a <http://www.nanopub.org/nschema#Nanopublication>;
+    <http://www.nanopub.org/nschema#hasAssertion> <http://purl.org/nanopub/temp/np/assertion>;
+    <http://www.nanopub.org/nschema#hasProvenance> <http://purl.org/nanopub/temp/np/provenance>;
+    <http://www.nanopub.org/nschema#hasPublicationInfo> <http://purl.org/nanopub/temp/np/pubinfo>
+}
+<http://purl.org/nanopub/temp/np/assertion> {
+<https://doi.org/10.1016/j.joclim.2025.100573> a <http://purl.org/spar/fabio/ScholarlyWork>;
+    <http://purl.org/spar/cito/usesDataFrom> <https://doi.org/10.1126/science.aar3646>
+}
+<http://purl.org/nanopub/temp/np/provenance> {
+<http://purl.org/nanopub/temp/np/assertion> <http://www.w3.org/ns/prov#wasAttributedTo> <https://orcid.org/0000-9999-1234-9999>
+}
+<http://purl.org/nanopub/temp/np/pubinfo> {
+<http://purl.org/nanopub/temp/np/> <http://purl.org/dc/terms/creator> <https://orcid.org/0000-9999-1234-9999>;
+    <http://purl.org/dc/terms/created> "2025-01-01T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/license> <https://creativecommons.org/licenses/by/4.0/>;
+    <http://purl.org/nanopub/x/hasNanopubType> <http://purl.org/spar/cito/cites>;
+    <http://purl.org/nanopub/x/wasCreatedAt> <https://platform.sciencelive4all.org>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Citations for: j.joclim.2025.100573";
+    <https://w3id.org/np/o/ntemplate/wasCreatedFromTemplate> <https://w3id.org/np/RAX_4tWTyjFpO6nz63s14ucuejd64t2mK3IBlkwZ7jjLo>.
+<https://orcid.org/0000-9999-1234-9999> <http://xmlns.com/foaf/0.1/name> "Test User1".
+<http://purl.org/nanopub/temp/np/sig> <http://purl.org/nanopub/x/signedBy> <https://orcid.org/0000-9999-1234-9999>
+}
+`;
+
+// An input to be signed, containing a CUSTOM placeholder URI
+const inputTrigCustom = `<https://w3id.org/sciencelive/np/Head> {
 <https://w3id.org/sciencelive/np/> a <http://www.nanopub.org/nschema#Nanopublication>;
     <http://www.nanopub.org/nschema#hasAssertion> <https://w3id.org/sciencelive/np/assertion>;
     <http://www.nanopub.org/nschema#hasProvenance> <https://w3id.org/sciencelive/np/provenance>;
@@ -32,8 +61,8 @@ const inputTrig = `<https://w3id.org/sciencelive/np/Head> {
 <https://orcid.org/0000-9999-1234-9999> <http://xmlns.com/foaf/0.1/name> "Test User1".
 <https://w3id.org/sciencelive/np/sig> <http://purl.org/nanopub/x/signedBy> <https://orcid.org/0000-9999-1234-9999>
 }
-`
-
+`;
+// The expected output for CUSTOM URI, nanopub-rs/sign
 const nanopub_rs_output = `PREFIX this: <https://w3id.org/sciencelive/np/RAvQgxo1ZGJRJGrDF-n0Qw6QL4zoZbOC2WM3DG8A47UME>
 PREFIX sub: <https://w3id.org/sciencelive/np/RAvQgxo1ZGJRJGrDF-n0Qw6QL4zoZbOC2WM3DG8A47UME/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -90,11 +119,11 @@ GRAPH sub:pubinfo {
     npx:hasSignatureTarget <https://w3id.org/sciencelive/np/RAvQgxo1ZGJRJGrDF-n0Qw6QL4zoZbOC2WM3DG8A47UME>;
     npx:signedBy orcid:0000-9999-1234-9999.
 }
-`
+`;
 
 describe('sign() with custom URI prefix', () => {
   it('returns signedRdf, sourceUri, and signature', async () => {
-    const result = await sign(inputTrig, EXAMPLE_privateKey);
+    const result = await sign(inputTrigCustom, EXAMPLE_privateKey);
 
     expect(result).toHaveProperty('signedRdf');
     expect(result).toHaveProperty('sourceUri');
@@ -104,9 +133,17 @@ describe('sign() with custom URI prefix', () => {
     expect(typeof result.signature).toBe('string');
   });
 
-  it('sourceUri matches the hash of nanopub-rs', async () => {
-    const { sourceUri } = await sign(inputTrig, EXAMPLE_privateKey);
-    const { sourceUri: sourceUri_rs, signedRdf: signedRdf_rs } = await sign_rs(inputTrig, EXAMPLE_privateKey, "https://orcid.org/0000-9999-1234-9999", "Test User1");
+  it('sourceUri matches the hash of nanopub-rs, standard URI', async () => {
+    const { sourceUri } = await sign(inputTrigStandard, EXAMPLE_privateKey, ORCID);
+    const { sourceUri: sourceUri_rs } = await sign_rs(inputTrigStandard, EXAMPLE_privateKey, ORCID, NAME);
+
+    // Check that both nanopub-js and nanopub-rs trusty URI exactly matches
+    expect(sourceUri).toBe(sourceUri_rs);
+  });
+
+  it('sourceUri matches the hash of nanopub-rs, CUSTOM URI', async () => {
+    const { sourceUri } = await sign(inputTrigCustom, EXAMPLE_privateKey, ORCID);
+    const { sourceUri: sourceUri_rs, signedRdf: signedRdf_rs } = await sign_rs(inputTrigCustom, EXAMPLE_privateKey, ORCID, NAME);
 
     // Check that nanopub-rs/sign output exactly matches the expectation
     expect(signedRdf_rs).toBe(nanopub_rs_output);
@@ -116,41 +153,41 @@ describe('sign() with custom URI prefix', () => {
   });
 
   it('signedRdf contains the trusty sourceUri', async () => {
-    const { signedRdf, sourceUri } = await sign(inputTrig, EXAMPLE_privateKey);
+    const { signedRdf, sourceUri } = await sign(inputTrigCustom, EXAMPLE_privateKey);
     expect(signedRdf).toContain(sourceUri);
   });
 
   it('signedRdf contains hasPublicKey and hasSignature triples', async () => {
-    const { signedRdf } = await sign(inputTrig, EXAMPLE_privateKey);
+    const { signedRdf } = await sign(inputTrigCustom, EXAMPLE_privateKey);
     expect(signedRdf).toContain('hasPublicKey');
     expect(signedRdf).toContain('hasSignature');
   });
 
   it('signedRdf no longer contains the temp placeholder URI', async () => {
-    const { signedRdf } = await sign(inputTrig, EXAMPLE_privateKey);
+    const { signedRdf } = await sign(inputTrigCustom, EXAMPLE_privateKey);
     expect(signedRdf).not.toContain('http://purl.org/nanopub/temp/np');
   });
 
   it('includes signedBy triple when orcid is provided', async () => {
-    const { signedRdf } = await sign(inputTrig, EXAMPLE_privateKey, ORCID);
+    const { signedRdf } = await sign(inputTrigCustom, EXAMPLE_privateKey, ORCID);
     expect(signedRdf).toContain('signedBy');
     expect(signedRdf).toContain(ORCID);
   });
 
   it('omits signedBy triple when orcid is not provided', async () => {
-    const { signedRdf } = await sign(inputTrig, EXAMPLE_privateKey);
+    const { signedRdf } = await sign(inputTrigCustom, EXAMPLE_privateKey);
     expect(signedRdf).not.toContain('signedBy');
   });
 
   it('signature is a non-empty base64 string', async () => {
-    const { signature } = await sign(inputTrig, EXAMPLE_privateKey);
+    const { signature } = await sign(inputTrigCustom, EXAMPLE_privateKey);
     expect(signature.length).toBeGreaterThan(0);
     expect(() => atob(signature)).not.toThrow();
   });
 
   it('two calls with the same key produce the same trusty hash (RSASSA-PKCS1-v1_5 is deterministic)', async () => {
-    const r1 = await sign(inputTrig, EXAMPLE_privateKey);
-    const r2 = await sign(inputTrig, EXAMPLE_privateKey);
+    const r1 = await sign(inputTrigCustom, EXAMPLE_privateKey);
+    const r2 = await sign(inputTrigCustom, EXAMPLE_privateKey);
     expect(r1.sourceUri).toBe(r2.sourceUri);
     expect(r1.signature).toBe(r2.signature);
   });

--- a/tests/sign/sign-custom-uri.test.ts
+++ b/tests/sign/sign-custom-uri.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { generateKeyPairSync } from 'crypto';
+import { sign } from '../../src/sign/sign';
+ import { sign as sign_rs } from '../../src/sign/sign-rs';
+
+const ORCID = 'https://orcid.org/0000-0000-0000-0000';
+
+const EXAMPLE_privateKey =
+  "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNQEcoXXchdpTm71Tidhyr1BMJp8jYeVg7/oLbmE5WOJ0hilSH/bmivywB+HoTOr6/3tpinw0Bws2M2m/7LLnDaaeYB5RC2DoD2BKBa499yOHa3rGMGOh/viyCGOJbjFPINlMhsIzsr+wvktHw0JclfW508lHmudjzR1/6B3OPdbj6Xw292VHIRt2WdyCmPEc8/3zvzuycQ3xsURnMxRoAdFqIf5iP30pn9uqP+Ex1rUaZ4lbrU8AuNPys3fiIPDVTYgsh4alY/IcYvd5OCvn2uw4LoXd/JZb9EJuS1KYK9v/DRirCdlvSNh4hy5UE7/nNgmXDt3xYjDfzOYN/8N9hAgMBAAECggEANbec5/OOOjPOxKHelWZUGqRmVyCScBVSAmGZ3d7+oZIvjZemh/DfpLhjzCA70syNH6ozfZwiy1MweKyyogoSlBISyrcxFk2A4YCrVzPPWhw5AA9IaGIcd1JOU74vf8Y6JywQlcCfIVLpfYnvaBcvd6BcSD8jMD9ziDgl5koM9H5iVDAr/J7XTm7iRxT3keCmfwBSs1rI0HB156e/QvG8eX/XX4hqrTJsRzC9S6wwkD/KSxan+ZHqN5d5eRI/3g9AYXNRqj0Nq2GOR2m4yC4UbL3ua7gEGxueErbKIm6uzWnCZSSV5fWXAALCmgILHeMpMMTej9+nd9ha2D3gJAoAAQKBgQDPV2sXW97OaL7jnTKd6tFbPgjrZ4YdkP917XTpOkhldJmiwhCDWo5BUSeo0aihB0rYwDNpGNgyBA9BNM5lBSCWrpAT3FMWrsUX6Y5Lg9UBaY5eXATmqf29YZPrWHG5b0vuU4MB59GzMPzAnzlysxLarzPbQBvXSeCNwLXtTKukcQKBgQD9a0Yb7FMNNHQlG8lOkftGRRIBejt+KPpg4cLF57nZJ5xgYaky+aiJLzZaof2Tmo7tsB3tlHv59opA9BCjB6iJ23OXTuO1Z5nqwH/PLe3m9QUd3syRgJ9a04is/GdxcUWUFG8shIBn1Gv0AYvZPwYXLduvdU5mnfTwKJfClvCh8QKBgQCfG3Mniq1QcZrCadf0zMP5I4KOunN1btZKNXz4mGwDxtU6y3cGhVASmWc4qiKf50utRthsts74mprmK9KSPLwERVJ0myb7igPe1LAIDNNA8TJ6AF0WcK4xTJbJC6bBaMG40kb/CFioDFh4q/bWqMo4HChMAEcdDykNPiudPK+eUQKBgQCWKuIxm7mfIo0MjEme0Gx4uGcyDu+AE+JCVKVpRqZfYtSMXHK57S0Mlbh8vm8X70dw26LwbMOGXKySTs4o/VnGzw7RA4N1tH2FmSpjZ5EJAfpVN/g65GAJnz3nW+4kT/3uAKncVGwOmtaZke0AABOo2pjKgRXDQyiowzUirvTK0QKBgQDOKqcTGGphC1pIpF/SUtdya0YXNoNoPtFBG5YmWjW0X7MonCisR0ffMsbqJWD00q2rzNG9kTU6u/3lKHrFFVktFQRYj4DJcLBxowt2j/WNiUOekFFw/xFbTCq7Sb2IoYUnQQPETKkrSq1WaAJ30rQRjhbXlpTPBOXj+tUrZ/BS+w==";
+
+const inputTrig = `<https://w3id.org/sciencelive/np/Head> {
+<https://w3id.org/sciencelive/np/> a <http://www.nanopub.org/nschema#Nanopublication>;
+    <http://www.nanopub.org/nschema#hasAssertion> <https://w3id.org/sciencelive/np/assertion>;
+    <http://www.nanopub.org/nschema#hasProvenance> <https://w3id.org/sciencelive/np/provenance>;
+    <http://www.nanopub.org/nschema#hasPublicationInfo> <https://w3id.org/sciencelive/np/pubinfo>
+}
+<https://w3id.org/sciencelive/np/assertion> {
+<https://doi.org/10.1016/j.joclim.2025.100573> a <http://purl.org/spar/fabio/ScholarlyWork>;
+    <http://purl.org/spar/cito/usesDataFrom> <https://doi.org/10.1126/science.aar3646>
+}
+<https://w3id.org/sciencelive/np/provenance> {
+<https://w3id.org/sciencelive/np/assertion> <http://www.w3.org/ns/prov#wasAttributedTo> <https://orcid.org/0000-9999-1234-9999>
+}
+<https://w3id.org/sciencelive/np/pubinfo> {
+<https://w3id.org/sciencelive/np/> <http://purl.org/dc/terms/creator> <https://orcid.org/0000-9999-1234-9999>;
+    <http://purl.org/dc/terms/created> "2025-01-01T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/license> <https://creativecommons.org/licenses/by/4.0/>;
+    <http://purl.org/nanopub/x/hasNanopubType> <http://purl.org/spar/cito/cites>;
+    <http://purl.org/nanopub/x/wasCreatedAt> <https://platform.sciencelive4all.org>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Citations for: j.joclim.2025.100573";
+    <https://w3id.org/np/o/ntemplate/wasCreatedFromTemplate> <https://w3id.org/np/RAX_4tWTyjFpO6nz63s14ucuejd64t2mK3IBlkwZ7jjLo>.
+<https://orcid.org/0000-9999-1234-9999> <http://xmlns.com/foaf/0.1/name> "Test User1".
+<https://w3id.org/sciencelive/np/sig> <http://purl.org/nanopub/x/signedBy> <https://orcid.org/0000-9999-1234-9999>
+}
+`
+
+const nanopub_rs_output = `PREFIX this: <https://w3id.org/sciencelive/np/RAvQgxo1ZGJRJGrDF-n0Qw6QL4zoZbOC2WM3DG8A47UME>
+PREFIX sub: <https://w3id.org/sciencelive/np/RAvQgxo1ZGJRJGrDF-n0Qw6QL4zoZbOC2WM3DG8A47UME/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX np: <http://www.nanopub.org/nschema#>
+PREFIX npx: <http://purl.org/nanopub/x/>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX schema: <https://schema.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX orcid: <https://orcid.org/>
+PREFIX biolink: <https://w3id.org/biolink/vocab/>
+PREFIX infores: <https://w3id.org/biolink/infores/>
+
+GRAPH sub:Head {
+  <https://w3id.org/sciencelive/np/RAvQgxo1ZGJRJGrDF-n0Qw6QL4zoZbOC2WM3DG8A47UME> a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo.
+}
+
+GRAPH sub:assertion {
+  <https://doi.org/10.1016/j.joclim.2025.100573> a <http://purl.org/spar/fabio/ScholarlyWork>;
+    <http://purl.org/spar/cito/usesDataFrom> <https://doi.org/10.1126/science.aar3646>.
+}
+
+GRAPH sub:provenance {
+  sub:assertion
+    prov:wasAttributedTo orcid:0000-9999-1234-9999.
+}
+
+GRAPH sub:pubinfo {
+  orcid:0000-9999-1234-9999
+    foaf:name "Test User1".
+
+  <https://w3id.org/sciencelive/np/RAvQgxo1ZGJRJGrDF-n0Qw6QL4zoZbOC2WM3DG8A47UME>
+    dcterms:created "2025-01-01T00:00:00.000Z"^^xsd:dateTime;
+    dcterms:creator orcid:0000-9999-1234-9999;
+    dcterms:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:hasNanopubType <http://purl.org/spar/cito/cites>;
+    npx:wasCreatedAt <https://platform.sciencelive4all.org>;
+    rdfs:label "Citations for: j.joclim.2025.100573";
+    <https://w3id.org/np/o/ntemplate/wasCreatedFromTemplate> <https://w3id.org/np/RAX_4tWTyjFpO6nz63s14ucuejd64t2mK3IBlkwZ7jjLo>.
+
+  sub:sig
+    npx:hasAlgorithm "RSA";
+    npx:hasPublicKey "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUBHKF13IXaU5u9U4nYcq9QTCafI2HlYO/6C25hOVjidIYpUh/25or8sAfh6Ezq+v97aYp8NAcLNjNpv+yy5w2mnmAeUQtg6A9gSgWuPfcjh2t6xjBjof74sghjiW4xTyDZTIbCM7K/sL5LR8NCXJX1udPJR5rnY80df+gdzj3W4+l8NvdlRyEbdlncgpjxHPP98787snEN8bFEZzMUaAHRaiH+Yj99KZ/bqj/hMda1GmeJW61PALjT8rN34iDw1U2ILIeGpWPyHGL3eTgr59rsOC6F3fyWW/RCbktSmCvb/w0YqwnZb0jYeIcuVBO/5zYJlw7d8WIw38zmDf/DfYQIDAQAB";
+    npx:hasSignature "xX2g3DFYR5FTCa9MEXlERiXBaPx9N/Phw95bqOcgY1YJKaCBXusQx2YKpnrZGTMPCaOcYEDNm93h4KmOvKiGT17mNn1KNPO5+yoO9alMzYDoPgOjmLUEQ4mkkAKqZbIlj7emsLNIOXC+bl1WO02rZ7LzVXfwbVWHaVehp7NAKh32KOl6R2J27sBPICR/EH2b4+FjLsBz+tGxyFseZAABUclhFECXeEc8vp8CBH4LLpLgBkY6vPpuwmucUyybt+I214JK8/zA/BKLL2+a6guxLQX+PuiW41hNEfsAsTLACEtIsKl5AFxIMNdu9+W9Y4008BltPSKTnhW6B4o1cQJEvw==";
+    npx:hasSignatureTarget <https://w3id.org/sciencelive/np/RAvQgxo1ZGJRJGrDF-n0Qw6QL4zoZbOC2WM3DG8A47UME>;
+    npx:signedBy orcid:0000-9999-1234-9999.
+}
+`
+
+describe('sign() with custom URI prefix', () => {
+  it('returns signedRdf, sourceUri, and signature', async () => {
+    const result = await sign(inputTrig, EXAMPLE_privateKey);
+
+    expect(result).toHaveProperty('signedRdf');
+    expect(result).toHaveProperty('sourceUri');
+    expect(result).toHaveProperty('signature');
+    expect(typeof result.signedRdf).toBe('string');
+    expect(typeof result.sourceUri).toBe('string');
+    expect(typeof result.signature).toBe('string');
+  });
+
+  it('sourceUri matches the hash of nanopub-rs', async () => {
+    const { sourceUri } = await sign(inputTrig, EXAMPLE_privateKey);
+    const { sourceUri: sourceUri_rs, signedRdf: signedRdf_rs } = await sign_rs(inputTrig, EXAMPLE_privateKey, "https://orcid.org/0000-9999-1234-9999", "Test User1");
+
+    // Check that nanopub-rs/sign output exactly matches the expectation
+    expect(signedRdf_rs).toBe(nanopub_rs_output);
+
+    // Check that both nanopub-js and nanopub-rs trusty URI exactly matches
+    expect(sourceUri).toBe(sourceUri_rs);
+  });
+
+  it('signedRdf contains the trusty sourceUri', async () => {
+    const { signedRdf, sourceUri } = await sign(inputTrig, EXAMPLE_privateKey);
+    expect(signedRdf).toContain(sourceUri);
+  });
+
+  it('signedRdf contains hasPublicKey and hasSignature triples', async () => {
+    const { signedRdf } = await sign(inputTrig, EXAMPLE_privateKey);
+    expect(signedRdf).toContain('hasPublicKey');
+    expect(signedRdf).toContain('hasSignature');
+  });
+
+  it('signedRdf no longer contains the temp placeholder URI', async () => {
+    const { signedRdf } = await sign(inputTrig, EXAMPLE_privateKey);
+    expect(signedRdf).not.toContain('http://purl.org/nanopub/temp/np');
+  });
+
+  it('includes signedBy triple when orcid is provided', async () => {
+    const { signedRdf } = await sign(inputTrig, EXAMPLE_privateKey, ORCID);
+    expect(signedRdf).toContain('signedBy');
+    expect(signedRdf).toContain(ORCID);
+  });
+
+  it('omits signedBy triple when orcid is not provided', async () => {
+    const { signedRdf } = await sign(inputTrig, EXAMPLE_privateKey);
+    expect(signedRdf).not.toContain('signedBy');
+  });
+
+  it('signature is a non-empty base64 string', async () => {
+    const { signature } = await sign(inputTrig, EXAMPLE_privateKey);
+    expect(signature.length).toBeGreaterThan(0);
+    expect(() => atob(signature)).not.toThrow();
+  });
+
+  it('two calls with the same key produce the same trusty hash (RSASSA-PKCS1-v1_5 is deterministic)', async () => {
+    const r1 = await sign(inputTrig, EXAMPLE_privateKey);
+    const r2 = await sign(inputTrig, EXAMPLE_privateKey);
+    expect(r1.sourceUri).toBe(r2.sourceUri);
+    expect(r1.signature).toBe(r2.signature);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,6 +8,11 @@ export default defineConfig({
     environment: "node",
     setupFiles: ["./tests/setup.ts"],
     include: ["tests/**/*.test.ts"],
+    server: {
+      deps: {
+        inline: ["@nanopub/sign"],  // This is only required for vitest to work with nanopub-rs (wasm)
+      },
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,6 +481,7 @@ __metadata:
   resolution: "@nanopub/nanopub-js@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.39.2"
+    "@nanopub/sign": "npm:^0.1.10"
     "@rdfjs/data-model": "npm:^2.1.1"
     "@rdfjs/types": "npm:^2.0.1"
     "@types/n3": "npm:^1"
@@ -503,6 +504,13 @@ __metadata:
     vitest: "npm:^3.2.4"
   languageName: unknown
   linkType: soft
+
+"@nanopub/sign@npm:^0.1.10":
+  version: 0.1.10
+  resolution: "@nanopub/sign@npm:0.1.10"
+  checksum: 10c0/af5c5cd06938eb15e1d78f9b51b86e8c4a30841065a92c525846f5bc04226ad7ea08918c54f70ac5bd0b466eadbcee70e811a3fb4522d8b013982bb9996323bf
+  languageName: node
+  linkType: hard
 
 "@npmcli/agent@npm:^4.0.0":
   version: 4.0.0


### PR DESCRIPTION
The actually fixes to review are all in `sign.ts` and `verify.ts`.

 I added test cases in `sign-custom-uri.test.ts` that use nanopub-rs sign and compare the output trustyURIs to confirm that there was an issue with incorrect hashes, and that it now passes correctly after the fix.

Once this is done, I'd also suggest removing the old `wasm` and `@nanopub/sign` stuff by searching the repo for those key words and deleting anything associated with it or supporting it.  You can probably also remove or streamline the `sign-custom-uri.test.ts` file which currently relies on wasm, or merge useful parts into `sign.test.ts`.