### PR TITLE
test(sign): cover signers that are a sub-IRI of the signed nanopub

### DIFF
--- a/src/nanopub.ts
+++ b/src/nanopub.ts
@@ -20,6 +20,10 @@ export class Nanopub implements NanopubData {
   privateKey?: string;
   private _profileParams?: {
     privateKey: string;
+    /**
+     * IRI of the signer, typically an ORCID iD. It may also be a sub-IRI of the
+     * nanopub being signed, to self-sign an agent's own introduction.
+     */
     orcid: string;
     name: string;
     email?: string;

--- a/src/sign/sign.ts
+++ b/src/sign/sign.ts
@@ -108,6 +108,16 @@ function replaceArtifactCodePlaceholder(dataset: Store, artifactCode: string): S
   return out;
 }
 
+/**
+ * Signs a nanopub and returns it with its trusty URI applied.
+ *
+ * @param trig - The unsigned nanopub in TriG.
+ * @param privateKeyBase64 - The RSA private key, base64 of the PKCS#8 DER.
+ * @param orcid - IRI of the signer recorded as `npx:signedBy`, typically an
+ * ORCID iD. It may also be a sub-IRI of the nanopub being signed, so that an
+ * agent can self-sign its own introduction in a single step; such an IRI is
+ * resolved to the final trusty sub-IRI along with every other self-reference.
+ */
 export async function sign(
   trig: string,
   privateKeyBase64: string,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -15,6 +15,10 @@ export interface NanopubOptions {
 
   privateKey?: string;
   name?: string;
+  /**
+   * IRI of the signer, typically an ORCID iD. It may also be a sub-IRI of the
+   * nanopub being signed, to self-sign an agent's own introduction.
+   */
   orcid?: string;
   email?: string;
 }

--- a/tests/sign/sign-self-signed.test.ts
+++ b/tests/sign/sign-self-signed.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { generateKeyPairSync } from 'crypto';
+import { sign } from '../../src/sign/sign';
+import { verifySignature } from '../../src/sign/verify';
+
+// An agent's IRI should be a sub-IRI of its own introduction, so that the
+// introduction can be self-signed with the agent's key in a single step. The
+// signer IRI must therefore go through the same temp-URI replacement as every
+// other term, both when normalizing (so it is hashed as a self-reference) and
+// when emitting the final trusty URIs.
+//
+// See nanopub-java issue #127 / PR #128, where the signer statement was added
+// after the temp-URI replacement pass and kept its raw temp URI.
+
+const TEMP_PREFIX = 'http://purl.org/nanopub/temp/';
+const BOT = `${TEMP_PREFIX}np/my-bot`;
+const ORCID = 'https://orcid.org/0000-9999-1234-9999';
+
+// A key declaration introducing `sub:my-bot`, the agent that also signs it.
+const INTRO_TRIG = `\
+@prefix sub: <http://purl.org/nanopub/temp/np/>.
+@prefix np: <http://www.nanopub.org/nschema#>.
+@prefix npx: <http://purl.org/nanopub/x/>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+sub:Head {
+  <http://purl.org/nanopub/temp/np> a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo
+}
+sub:assertion {
+  sub:keyDeclaration npx:declaredBy sub:my-bot;
+    npx:hasAlgorithm "RSA".
+  sub:my-bot foaf:name "My Bot"
+}
+sub:provenance {
+  sub:assertion prov:wasAttributedTo sub:my-bot
+}
+sub:pubinfo {
+  <http://purl.org/nanopub/temp/np> prov:wasAttributedTo sub:my-bot
+}
+`;
+
+let privateKeyBase64: string;
+
+beforeAll(() => {
+  const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  privateKeyBase64 = privateKey
+    .replace('-----BEGIN PRIVATE KEY-----', '')
+    .replace('-----END PRIVATE KEY-----', '')
+    .replace(/\r?\n|\r/g, '');
+});
+
+describe('sign() with a signer that is a sub-IRI of the signed nanopub', () => {
+  it('replaces the temp signer IRI with the trusty sub-IRI', async () => {
+    const { signedRdf, sourceUri } = await sign(INTRO_TRIG, privateKeyBase64, BOT);
+
+    expect(signedRdf).not.toContain(TEMP_PREFIX);
+    expect(signedRdf).toContain('npx:signedBy');
+    expect(signedRdf).toContain(`${sourceUri}/`);
+  });
+
+  it('keeps the self-signed nanopub verifiable', async () => {
+    // The signer IRI is part of the hash, so it must normalize to a
+    // self-reference in exactly the same way when signing and when verifying.
+    const { signedRdf } = await sign(INTRO_TRIG, privateKeyBase64, BOT);
+
+    await expect(verifySignature(signedRdf)).resolves.toEqual({ valid: true });
+  });
+
+  it('leaves an external signer IRI untouched', async () => {
+    const { signedRdf } = await sign(INTRO_TRIG, privateKeyBase64, ORCID);
+
+    expect(signedRdf).toContain(ORCID);
+    await expect(verifySignature(signedRdf)).resolves.toEqual({ valid: true });
+  });
+});

--- a/tests/sign/sign-self-signed.test.ts
+++ b/tests/sign/sign-self-signed.test.ts
@@ -14,7 +14,7 @@ import { verifySignature } from '../../src/sign/verify';
 
 const TEMP_PREFIX = 'http://purl.org/nanopub/temp/';
 const BOT = `${TEMP_PREFIX}np/my-bot`;
-const ORCID = 'https://orcid.org/0000-9999-1234-9999';
+const ORCID = 'https://orcid.org/0000-0002-1825-0097';
 
 // A key declaration introducing `sub:my-bot`, the agent that also signs it.
 const INTRO_TRIG = `\


### PR DESCRIPTION
Follow-up to [nanopub-java#127](https://github.com/Nanopublication/nanopub-java/issues/127) / [nanopub-java#128](https://github.com/Nanopublication/nanopub-java/pull/128), checking whether the same defect exists here.

## Summary

**It does not — nanopub-js already handles this correctly.** This PR adds the regression coverage that was missing, plus documentation for the signer parameter. No behaviour changes.

In nanopub-java, temp-URI replacement ran *before* the signer statement was added, so a signer under `http://purl.org/nanopub/temp/…` was hashed as an external IRI and emitted with its raw temp URI, breaking self-signed agent introductions ("The signer is not a creator").

nanopub-js has the opposite ordering and is unaffected:

1. `npx:signedBy` is added verbatim in `sign()` **before** either normalization pass.
2. Both passes call `normalizeDataset(dataset, placeholder, trustyBase)`, whose `normalizeUri` maps anything under the base to `normUri + '/' + local` — so a signer sub-IRI normalizes as a self-reference rather than an external IRI.
3. `replaceNanopubUri(dataset, placeholder, trustyUri)` rewrites every `NamedNode` under the old base, the `signedBy` object included.

`verifySignature` re-normalizes against the trusty URI and hits the same branch, so signing and verification agree.

## Changes

- **`tests/sign/sign-self-signed.test.ts`** (new) — signs a key-declaration introduction whose signer is `http://purl.org/nanopub/temp/np/my-bot` and asserts the temp prefix is gone, the signer resolves to the trusty sub-IRI, and the result still verifies. A third case pins that an external ORCID signer is left untouched.
- **JSDoc on the `orcid` parameter** in `src/sign/sign.ts`, `src/types/types.ts` and `src/nanopub.ts`, noting it accepts any agent IRI including a sub-IRI of the nanopub being signed. **The field name is unchanged** so the public API stays stable.

## Verification

The tests were mutation-checked rather than merely observed to pass. Exempting `signedBy` from the replacement pass — reproducing the nanopub-java defect — fails both self-signed assertions while the external-signer control stays green:

```
× replaces the temp signer IRI with the trusty sub-IRI
  → expected '@prefix this: <https://w3id.org/np/RA…' not to contain 'http://purl.org/nanopub/temp/'
× keeps the self-signed nanopub verifiable
  → expected { valid: false, …(1) } to deeply equal { valid: true }
✓ leaves an external signer IRI untouched
```

The second failure is the important one: it shows the signer IRI genuinely participates in the hash, so this is not just a string-rewrite check.

Full suite: **124 passed, 1 failed** — the failure is `client.integration.test.ts > fetchNanopub returns json-ld`, a network timeout against `w3id.org`, unrelated to these changes. `tsc --noEmit` is clean; `eslint` reports only two pre-existing `no-unused-vars` errors in `tests/client.test.ts`.

The equivalent regression test and CLI help update have landed in nanopub-py (`c1db20a`, `07d2286`); it was likewise already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
