### PR TITLE
test(sign): cover `~~~ARTIFACTCODE~~~` substitution

### DIFF
--- a/src/sign/sign.ts
+++ b/src/sign/sign.ts
@@ -88,7 +88,7 @@ function replaceNanopubUri(dataset: Store, oldBase: string, newBase: string): St
  * https://example.org/ns/RA...). The nanopub's own base URI is handled
  * separately by replaceNanopubUri.
  */
-function replaceArtifactCodePlaceholder(dataset: Store, artifactCode: string): Store {
+export function replaceArtifactCodePlaceholder(dataset: Store, artifactCode: string): Store {
   const out = new Store();
   const sub = (v: string) =>
     v.split('~~~ARTIFACTCODE~~~').join(artifactCode).split('ARTIFACTCODE-PLACEHOLDER').join(artifactCode);

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -59,7 +59,7 @@ describe("NanopubClient (unit)", () => {
     });
 
     const client = new NanopubClient();
-    expect(client.querySparql("SELECT * WHERE {?s ?p ?o}")).rejects.toThrow(
+    await expect(client.querySparql("SELECT * WHERE {?s ?p ?o}")).rejects.toThrow(
       /SPARQL query failed/
     );
   });

--- a/tests/sign/artifactcode.test.ts
+++ b/tests/sign/artifactcode.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Unit tests for `~~~ARTIFACTCODE~~~` placeholder handling.
+ *
+ * The placeholder may appear in ANY URI, not just the nanopub's own base URI:
+ * a nanopub keeping the default `w3id.org/np` URI can still mint a concept in
+ * its own namespace (`https://example.org/ns/~~~ARTIFACTCODE~~~`).
+ *
+ * Covers:
+ *  - replaceArtifactCodePlaceholder(): substitution after the code is known
+ *  - detectNanopubBaseUri(): base detection / placeholder stripping (expandBaseUri)
+ *  - normalizeDataset(): blanking the placeholder (signing) and this nanopub's
+ *    own artifact code (verification) so the hash never depends on itself
+ *
+ * The end-to-end substitution is pinned against the reference implementation by
+ * the `artifactcode-1` transform case in tests/sign/testsuite.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DataFactory, Store } from 'n3';
+
+import {
+  detectNanopubBaseUri,
+  ensureTrailingSlash,
+  replaceArtifactCodePlaceholder,
+} from '../../src/sign/sign';
+import { normalizeDataset } from '../../src/sign/utils';
+import { DEFAULT_NANOPUB_URI, TRUSTY_BASE } from '../../src/constants';
+import { NP, RDF } from '../../src/vocab';
+
+const { namedNode, literal, quad, defaultGraph } = DataFactory;
+
+const PLACEHOLDER = '~~~ARTIFACTCODE~~~';
+const DEPRECATED_PLACEHOLDER = 'ARTIFACTCODE-PLACEHOLDER';
+
+/** Artifact code of the nanopub under test (RA + 43 base64url chars). */
+const CODE = 'RAO8Bidt02PViTDmvylhId8vx6ZzBkFeY728tiHZqFTyM';
+/** A reference to some OTHER trusty nanopub — must never be touched. */
+const OTHER_CODE = 'RAbcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN_123';
+
+/** Build a single-quad store, for the common "one URI in one position" cases. */
+function storeOf(...quads: ReturnType<typeof quad>[]): Store {
+  const store = new Store();
+  for (const q of quads) store.addQuad(q);
+  return store;
+}
+
+/** All URIs occurring in the store, in insertion order, as flat strings. */
+function uris(store: Store): string[] {
+  const out: string[] = [];
+  for (const q of store) {
+    for (const term of [q.graph, q.subject, q.predicate, q.object]) {
+      if (term.termType === 'NamedNode') out.push(term.value);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// replaceArtifactCodePlaceholder
+// ---------------------------------------------------------------------------
+
+describe('replaceArtifactCodePlaceholder()', () => {
+  it('substitutes the placeholder in every term position, in any namespace', () => {
+    const store = storeOf(quad(
+      namedNode(`https://example.org/ns/${PLACEHOLDER}`),
+      namedNode(`https://example.org/p/${PLACEHOLDER}`),
+      namedNode(`https://other.example/${PLACEHOLDER}#o`),
+      namedNode(`https://example.org/g/${PLACEHOLDER}`),
+    ));
+
+    const result = replaceArtifactCodePlaceholder(store, CODE);
+
+    expect(uris(result)).toEqual([
+      `https://example.org/g/${CODE}`,
+      `https://example.org/ns/${CODE}`,
+      `https://example.org/p/${CODE}`,
+      `https://other.example/${CODE}#o`,
+    ]);
+  });
+
+  it('substitutes the deprecated ARTIFACTCODE-PLACEHOLDER', () => {
+    const store = storeOf(quad(
+      namedNode(`https://example.org/ns/${DEPRECATED_PLACEHOLDER}`),
+      RDF('type'),
+      namedNode('http://www.w3.org/2004/02/skos/core#Concept'),
+      defaultGraph(),
+    ));
+
+    const result = replaceArtifactCodePlaceholder(store, CODE);
+
+    expect([...result][0].subject.value).toBe(`https://example.org/ns/${CODE}`);
+  });
+
+  it('substitutes every occurrence within a single URI', () => {
+    const store = storeOf(quad(
+      namedNode(`https://example.org/${PLACEHOLDER}/${PLACEHOLDER}#x`),
+      RDF('type'),
+      namedNode('http://example.org/T'),
+      defaultGraph(),
+    ));
+
+    const result = replaceArtifactCodePlaceholder(store, CODE);
+
+    expect([...result][0].subject.value).toBe(`https://example.org/${CODE}/${CODE}#x`);
+  });
+
+  it('leaves URIs without a placeholder untouched, including other trusty URIs', () => {
+    const other = `https://w3id.org/np/${OTHER_CODE}`;
+    const store = storeOf(quad(
+      namedNode('https://example.org/ns/concept'),
+      namedNode('http://www.w3.org/2004/02/skos/core#related'),
+      namedNode(other),
+      defaultGraph(),
+    ));
+
+    const result = replaceArtifactCodePlaceholder(store, CODE);
+
+    expect(uris(result)).toEqual([
+      'https://example.org/ns/concept',
+      'http://www.w3.org/2004/02/skos/core#related',
+      other,
+    ]);
+  });
+
+  it('leaves literals untouched — only IRIs carry artifact codes', () => {
+    const store = storeOf(quad(
+      namedNode(`https://example.org/ns/${PLACEHOLDER}`),
+      namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
+      literal(`a term named ${PLACEHOLDER}`),
+      defaultGraph(),
+    ));
+
+    const result = replaceArtifactCodePlaceholder(store, CODE);
+    const [q] = [...result];
+
+    expect(q.subject.value).toBe(`https://example.org/ns/${CODE}`);
+    expect(q.object.value).toBe(`a term named ${PLACEHOLDER}`);
+  });
+
+  it('returns a new store and leaves the input dataset unchanged', () => {
+    const store = storeOf(quad(
+      namedNode(`https://example.org/ns/${PLACEHOLDER}`),
+      RDF('type'),
+      namedNode('http://example.org/T'),
+      defaultGraph(),
+    ));
+
+    const result = replaceArtifactCodePlaceholder(store, CODE);
+
+    expect(result).not.toBe(store);
+    expect([...store][0].subject.value).toBe(`https://example.org/ns/${PLACEHOLDER}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectNanopubBaseUri (and the placeholder stripping in expandBaseUri)
+// ---------------------------------------------------------------------------
+
+/** Minimal store declaring `uri` as the nanopub. */
+function nanopubStore(uri: string): Store {
+  const head = `${uri.replace(/\/$/, '')}/Head`;
+  return storeOf(quad(namedNode(uri), RDF('type'), NP('Nanopublication'), namedNode(head)));
+}
+
+describe('detectNanopubBaseUri()', () => {
+  it('maps the default temp URI to the standard trusty base', () => {
+    const { placeholder, trustyBase, existingTrustyUri } =
+      detectNanopubBaseUri(nanopubStore('http://purl.org/nanopub/temp/np'));
+
+    expect(placeholder).toBe(DEFAULT_NANOPUB_URI);
+    expect(trustyBase).toBe(TRUSTY_BASE);
+    expect(existingTrustyUri).toBeUndefined();
+  });
+
+  it('maps any other purl.org/nanopub/temp/ URI to the standard trusty base', () => {
+    const { placeholder, trustyBase } =
+      detectNanopubBaseUri(nanopubStore('http://purl.org/nanopub/temp/1029384756'));
+
+    expect(placeholder).toBe('http://purl.org/nanopub/temp/1029384756/');
+    expect(trustyBase).toBe(TRUSTY_BASE);
+  });
+
+  it('strips a `~~~ARTIFACTCODE~~~` segment from a custom base URI', () => {
+    const { placeholder, trustyBase, existingTrustyUri } =
+      detectNanopubBaseUri(nanopubStore(`https://w3id.org/sciencelive/np/${PLACEHOLDER}/`));
+
+    expect(placeholder).toBe(`https://w3id.org/sciencelive/np/${PLACEHOLDER}/`);
+    expect(trustyBase).toBe('https://w3id.org/sciencelive/np/');
+    expect(existingTrustyUri).toBeUndefined();
+  });
+
+  it('strips a `~~~ARTIFACTCODE~~~` segment written without a trailing separator', () => {
+    const { placeholder, trustyBase } =
+      detectNanopubBaseUri(nanopubStore(`https://w3id.org/sciencelive/np/${PLACEHOLDER}`));
+
+    // `~` is not a word character, so ensureTrailingSlash() adds no separator here.
+    expect(placeholder).toBe(`https://w3id.org/sciencelive/np/${PLACEHOLDER}`);
+    expect(trustyBase).toBe('https://w3id.org/sciencelive/np/');
+  });
+
+  it('strips the deprecated ARTIFACTCODE-PLACEHOLDER from a custom base URI', () => {
+    const { trustyBase } =
+      detectNanopubBaseUri(nanopubStore(`https://w3id.org/sciencelive/np/${DEPRECATED_PLACEHOLDER}`));
+
+    expect(trustyBase).toBe('https://w3id.org/sciencelive/np/');
+  });
+
+  it('keeps a custom base URI without a placeholder as the trusty base', () => {
+    const { placeholder, trustyBase } =
+      detectNanopubBaseUri(nanopubStore('https://w3id.org/sciencelive/np'));
+
+    expect(placeholder).toBe('https://w3id.org/sciencelive/np/');
+    expect(trustyBase).toBe('https://w3id.org/sciencelive/np/');
+  });
+
+  it('detects an existing trusty URI and returns its base prefix', () => {
+    const { placeholder, trustyBase, existingTrustyUri } =
+      detectNanopubBaseUri(nanopubStore(`https://w3id.org/np/${CODE}`));
+
+    expect(placeholder).toBe('https://w3id.org/np/');
+    expect(trustyBase).toBe('https://w3id.org/np/');
+    expect(existingTrustyUri).toBe(`https://w3id.org/np/${CODE}/`);
+  });
+});
+
+describe('ensureTrailingSlash()', () => {
+  it('appends a slash after an alphanumeric, hyphen or underscore', () => {
+    expect(ensureTrailingSlash('https://example.org/np')).toBe('https://example.org/np/');
+    expect(ensureTrailingSlash('https://example.org/np-1')).toBe('https://example.org/np-1/');
+    expect(ensureTrailingSlash('https://example.org/np_1')).toBe('https://example.org/np_1/');
+  });
+
+  it('leaves an existing / or # separator alone', () => {
+    expect(ensureTrailingSlash('https://example.org/np/')).toBe('https://example.org/np/');
+    expect(ensureTrailingSlash('https://example.org/np#')).toBe('https://example.org/np#');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeDataset: artifact-code blanking outside the nanopub's namespace
+// ---------------------------------------------------------------------------
+
+/**
+ * A nanopub that introduces a concept in its own foreign namespace.
+ * `code` is the placeholder while signing, the real artifact code afterwards.
+ */
+function introducingNanopub(base: string, code: string): Store {
+  const store = new Store();
+  const concept = namedNode(`https://example.org/ns/${code}`);
+  const head = namedNode(`${base}Head`);
+  const assertion = namedNode(`${base}assertion`);
+  const pubinfo = namedNode(`${base}pubinfo`);
+
+  store.addQuad(quad(namedNode(base.replace(/\/$/, '')), RDF('type'), NP('Nanopublication'), head));
+  store.addQuad(quad(concept, RDF('type'), namedNode('http://www.w3.org/2004/02/skos/core#Concept'), assertion));
+  store.addQuad(quad(concept, namedNode('http://www.w3.org/2004/02/skos/core#related'),
+    namedNode(`https://w3id.org/np/${OTHER_CODE}`), assertion));
+  store.addQuad(quad(namedNode(base.replace(/\/$/, '')),
+    namedNode('http://purl.org/nanopub/x/introduces'), concept, pubinfo));
+  return store;
+}
+
+describe('normalizeDataset() artifact-code blanking', () => {
+  it('blanks the placeholder in foreign-namespace URIs while signing', () => {
+    const normalized = normalizeDataset(
+      introducingNanopub(DEFAULT_NANOPUB_URI, PLACEHOLDER),
+      DEFAULT_NANOPUB_URI,
+      TRUSTY_BASE,
+    );
+
+    expect(normalized).not.toContain(PLACEHOLDER);
+    expect(normalized).toContain('https://example.org/ns/ ');
+  });
+
+  it('blanks the deprecated placeholder the same way', () => {
+    const normalized = normalizeDataset(
+      introducingNanopub(DEFAULT_NANOPUB_URI, DEPRECATED_PLACEHOLDER),
+      DEFAULT_NANOPUB_URI,
+      TRUSTY_BASE,
+    );
+
+    expect(normalized).not.toContain(DEPRECATED_PLACEHOLDER);
+    expect(normalized).toContain('https://example.org/ns/ ');
+  });
+
+  it("blanks this nanopub's own artifact code in foreign-namespace URIs while verifying", () => {
+    const trustyUri = `${TRUSTY_BASE}${CODE}`;
+    const normalized = normalizeDataset(
+      introducingNanopub(`${trustyUri}/`, CODE),
+      trustyUri,
+      TRUSTY_BASE,
+    );
+
+    expect(normalized).not.toContain(CODE);
+    expect(normalized).toContain('https://example.org/ns/ ');
+  });
+
+  it('normalizes identically before signing and on verification', () => {
+    const trustyUri = `${TRUSTY_BASE}${CODE}`;
+
+    const signing = normalizeDataset(
+      introducingNanopub(DEFAULT_NANOPUB_URI, PLACEHOLDER),
+      DEFAULT_NANOPUB_URI,
+      TRUSTY_BASE,
+    );
+    const verifying = normalizeDataset(
+      introducingNanopub(`${trustyUri}/`, CODE),
+      trustyUri,
+      TRUSTY_BASE,
+    );
+
+    expect(verifying).toBe(signing);
+  });
+
+  it('leaves references to other trusty nanopubs untouched', () => {
+    const normalized = normalizeDataset(
+      introducingNanopub(DEFAULT_NANOPUB_URI, PLACEHOLDER),
+      DEFAULT_NANOPUB_URI,
+      TRUSTY_BASE,
+    );
+
+    expect(normalized).toContain(`https://w3id.org/np/${OTHER_CODE}`);
+  });
+});

--- a/tests/sign/testsuite.test.ts
+++ b/tests/sign/testsuite.test.ts
@@ -6,6 +6,8 @@
  *
  * Covers:
  *  - Transform cases: sign each plain input and compare artifact code to expected
+ *  - `~~~ARTIFACTCODE~~~` substitution: the `artifactcode-1` case, which mints a
+ *    concept in a foreign namespace, pinned against the reference output
  *  - Valid TRUSTY entries: verifySignature() should pass for all
  *  - Invalid SIGNED/TRUSTY entries: verifySignature() should fail for all
  */
@@ -16,6 +18,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { NanopubTestSuite, TestSuiteSubfolder } from '@nanopub/nanopub-testsuite-connector-js';
 
 import { sign } from '../../src/sign/sign';
+import { parse } from '../../src/serialize';
 import { verifySignature } from '../../src/sign/verify';
 
 let suite: NanopubTestSuite;
@@ -48,6 +51,18 @@ function extractArtifactCode(uri: string): string {
   return uri.replace(/.*[/#]/, '');
 }
 
+/** Sorted N-Quads-ish lines, for comparing TriG documents regardless of serialization. */
+function toNquads(trig: string): string[] {
+  return parse(trig, 'trig')
+    .map(q => {
+      const object = q.object.termType === 'Literal'
+        ? `"${q.object.value}"${q.object.language ? `@${q.object.language}` : `^^<${q.object.datatype.value}>`}`
+        : `<${q.object.value}>`;
+      return `<${q.graph.value}> <${q.subject.value}> <${q.predicate.value}> ${object}`;
+    })
+    .sort();
+}
+
 // Transform cases
 describe('test suite: transform cases (sign)', () => {
   it('all transform cases produce the expected artifact code', async () => {
@@ -64,6 +79,62 @@ describe('test suite: transform cases (sign)', () => {
       expect(code, `${tc.keyName}/${tc.plain.name}`).toBe(tc.outCode);
     }
   }, 120_000);
+});
+
+// `~~~ARTIFACTCODE~~~` substitution, pinned against the reference implementation.
+//
+// `artifactcode-1` keeps the default temp nanopub URI but mints a concept in a
+// foreign namespace (`https://example.org/ns/~~~ARTIFACTCODE~~~`), so it pins
+// that the placeholder is substituted globally, not only inside the nanopub's
+// own base URI.
+describe('test suite: `~~~ARTIFACTCODE~~~` substitution (transform case)', () => {
+  const CASE_NAME = 'artifactcode-1';
+
+  function artifactCodeCase() {
+    const tc = suite.getTransformCases().find(c => c.plain.name.startsWith(`${CASE_NAME}.`));
+    expect(tc, `transform case '${CASE_NAME}' missing from suite ${SUITE_COMMIT}`).toBeDefined();
+    return tc!;
+  }
+
+  it('substitutes the placeholder in a foreign namespace with the reference artifact code', async () => {
+    const tc = artifactCodeCase();
+    const privKey = pemToBase64(suite.getSigningKey(tc.keyName).privateKey);
+
+    const { signedRdf, sourceUri } = await sign(tc.plain.readText(), privKey, profileOrcid);
+    const code = extractArtifactCode(sourceUri);
+
+    expect(code).toBe(tc.outCode);
+    expect(signedRdf).not.toMatch(/ARTIFACTCODE/);
+    expect(signedRdf).toContain(`https://example.org/ns/${code}`);
+    // The nanopub itself keeps the standard trusty base, only the concept moves.
+    expect(sourceUri).toBe(`https://w3id.org/np/${code}`);
+  }, 30_000);
+
+  it('produces the same quads as the reference signed output', async () => {
+    const tc = artifactCodeCase();
+    const privKey = pemToBase64(suite.getSigningKey(tc.keyName).privateKey);
+
+    const { signedRdf } = await sign(tc.plain.readText(), privKey, profileOrcid);
+
+    const expected = toNquads(tc.signed.readText());
+    expect(expected.length).toBeGreaterThan(0);
+    expect(toNquads(signedRdf)).toEqual(expected);
+  }, 30_000);
+
+  it('verifies the nanopub it signed', async () => {
+    const tc = artifactCodeCase();
+    const privKey = pemToBase64(suite.getSigningKey(tc.keyName).privateKey);
+
+    const { signedRdf } = await sign(tc.plain.readText(), privKey, profileOrcid);
+
+    expect(await verifySignature(signedRdf)).toEqual({ valid: true });
+  }, 30_000);
+
+  it('verifies the reference signed output', async () => {
+    const tc = artifactCodeCase();
+
+    expect(await verifySignature(tc.signed.readText())).toEqual({ valid: true });
+  }, 30_000);
 });
 
 // Signature verification: valid SIGNED entries


### PR DESCRIPTION
## Summary

The global (base-independent) `~~~ARTIFACTCODE~~~` substitution requested in #11 is already implemented — it landed in 5057525 and shipped in v0.1.2 — but it came with no tests of its own. The only coverage was the aggregate transform loop in `tests/sign/testsuite.test.ts`, where a regression would surface as an unnamed artifact-code mismatch among ~24 cases.

This PR closes that gap.

## Unit tests — `tests/sign/artifactcode.test.ts` (new, 20 tests)

- **`replaceArtifactCodePlaceholder()`** — substitution in every term position and in any namespace; the deprecated `ARTIFACTCODE-PLACEHOLDER`; repeated occurrences within one URI; references to *other* trusty URIs and literals left untouched; input dataset not mutated.
- **`detectNanopubBaseUri()`** (exercising the private `expandBaseUri`) — default and arbitrary `purl.org/nanopub/temp/` URIs → `TRUSTY_BASE`; both placeholders stripped from a custom base; custom base without a placeholder; existing trusty URI → base prefix + `existingTrustyUri`.
- **`ensureTrailingSlash()`** — separator appended after word characters, existing `/` or `#` kept.
- **`normalizeDataset()`** — the placeholder is blanked while signing, this nanopub's own `RA…` code while verifying, other trusty references stay verbatim, and both normalizations produce **identical** output. That last one is the invariant that keeps the trusty hash from depending on itself.

## Test-suite case — `tests/sign/testsuite.test.ts`

A dedicated block driven by the external suite's `artifactcode-1` transform case (added for Nanopublication/nanopub-testsuite#3, present at the pinned commit `cfe9630`). It keeps the default nanopub URI while minting a concept in a foreign namespace — exactly the scenario from #11:

- artifact code matches the reference `*.out.code`;
- no `ARTIFACTCODE` survives, the concept becomes `https://example.org/ns/<code>` while the nanopub keeps `https://w3id.org/np/<code>`;
- our signed output matches the reference `*.out.trig` **quad for quad** (new `toNquads()` helper, with a non-vacuity guard);
- both our output and the reference verify.

A renamed or missing case fails loudly instead of silently skipping.

## Source change

One word: `replaceArtifactCodePlaceholder()` is now exported so it can be unit-tested directly — consistent with the neighbouring `detectNanopubBaseUri()` and `ensureTrailingSlash()`, which `src/index.ts` already re-exports.

## Test plan

- `yarn vitest run` — 149 passed, 2 todo, 12 files
- `yarn tsc --noEmit` — clean
- `yarn lint` — only the two pre-existing `no-unused-vars` errors in `tests/client.test.ts`, untouched here

Refs #11 — with this merged, #11 can be closed as completed by 5057525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
